### PR TITLE
Add support for Combined Oceanic profile

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -44,6 +44,7 @@ namespace ATISPlugin
             if (Profile.Name.Contains("Australia")) return "Australia";
             else if (Profile.Name.Contains("South Pacific")) return "South Pacific";
             else if (Profile.Name.Contains("Pacific")) return "Pacific";
+            else if (Profile.Name.Contains("Combined Oceanic")) return "VATNZ Combined Oceanic";
             else if (Profile.Name.Contains("VATNZ")) return "New Zealand";
             else return string.Empty;
         }


### PR DESCRIPTION
Currently when used with the Oceanic Combined profile the profile being selected is the NZZC Domestic profile resulting in incorrect airports being presented.

This fixes to match on the Oceanic Combined profile as defined at https://github.com/vatSys/combined-oceanic-dataset/blob/main/Profile.xml