### PR TITLE
Improve wind output

### DIFF
--- a/EditorWindow.cs
+++ b/EditorWindow.cs
@@ -1472,7 +1472,7 @@ namespace ATISPlugin
 
             if (wind == "CALM") return "CALM";
 
-            if (wind == "VRB") return "VARIABLE";
+            if (wind == "LIGHT AND VRB") return "VARIABLE";
 
             var split = wind.Split('/');
 

--- a/METAR.cs
+++ b/METAR.cs
@@ -81,7 +81,7 @@ namespace ATISPlugin
 
                     var direction = wind.Substring(0, 3);
 
-                    var speed = wind.Substring(3, 2);
+                    var speed = wind.Substring(3, 2).TrimStart('0');
 
                     Wind = $"{direction}/{speed}";
 

--- a/METAR.cs
+++ b/METAR.cs
@@ -74,7 +74,7 @@ namespace ATISPlugin
 
                     if (wind.EndsWith("01") || wind.EndsWith("02") || wind.EndsWith("03"))
                     {
-                        Wind = "VRB";
+                        Wind = "LIGHT AND VRB";
 
                         continue;
                     }


### PR DESCRIPTION
Two small tweaks to improve the output of the wind from a deconstructed METAR.

1. Outputs `LIGHT AND VRB` (instead of the current `VRB`) when the wind speed is below 3kt. Different aerodromes seem to do this differently, with some using 'LIGHT AND VARIABLE' and others just defaulting to 'VARIABLE 5 KTS', but this is probably a good default
2. Removes the leading 0 in any wind speed below 10kt. This allows the text-to-speech to read the wind correctly as '_one eight zero degrees, 5 knots_', rather than the current '_one eight zero degrees, zero five knots_'.